### PR TITLE
feat: Add application confirmation email

### DIFF
--- a/ai_docs/masterplan.md
+++ b/ai_docs/masterplan.md
@@ -29,6 +29,7 @@ This document outlines the high-level development phases for ProjectVote. Each s
 ### 4.2 New Application Notification
 ### 4.3 Final Decision Notification
 ### 4.4 Configurable Rejection Emails
+### 4.5 Application Confirmation Notification
 
 ## 5. Integration & End-to-End Testing
 ### 5.1 Backend-Frontend Integration

--- a/ai_docs/requirements.md
+++ b/ai_docs/requirements.md
@@ -9,6 +9,7 @@ This document outlines the core functional requirements for the web application 
     *   A user-friendly form for entering project details (title, description, costs, department).
     *   Collection of applicant's contact information (name, email).
     *   Optional file upload for supporting documents (PDF, XLSX, DOCX, etc.).
+    *   Upon successful submission, the applicant receives a confirmation email containing all the details of their submission.
 
 ## 2. Token-Based Board Voting
 

--- a/ai_docs/task_4_5.md
+++ b/ai_docs/task_4_5.md
@@ -1,0 +1,34 @@
+# Task 4.5: Application Confirmation Notification
+
+## Goal
+Implement an automated confirmation email to the applicant upon successful submission of a new funding application, ensuring they have a record of their submission.
+
+## Plan
+1.  Create a new, dedicated email template for the applicant confirmation.
+2.  Integrate the email sending logic into the application submission endpoint.
+3.  Ensure all submitted data is included in the email for the applicant's reference.
+4.  Verify the functionality through testing and local email inspection.
+
+## Tasks
+
+### Phase 1: Email Template Creation
+*   [x] Create a new HTML email template named `application_confirmation.html` in `src/projectvote/backend/templates/email/`.
+*   [ ] The template should be designed to clearly display all key application details:
+    *   Applicant's Full Name
+    *   Applicant's Email
+    *   Department
+    *   Project Title
+    *   Project Description
+    *   Estimated Costs
+*   [x] The template should also acknowledge if a file was attached (e.g., "Your attachment '[filename]' was successfully uploaded.").
+*   [x] The template should contain a link to the archive of the web app.
+
+### Phase 2: Backend Integration
+*   [x] Modify the `submit_application` function in `src/projectvote/backend/main.py`.
+*   [x] After successfully saving the application and any attachments, call the `send_email` function.
+*   [x] The recipient for this email should be the `applicant_email` from the submitted data.
+*   [x] Pass all necessary application data (including details of the attachment, if any) to the `application_confirmation.html` template.
+
+### Phase 3: Verification
+*   [x] Add a unit test to verify that the email sending function is called with the correct parameters (recipient, subject, template) upon a successful application submission.
+*   [x] Use MailHog during local development to visually inspect the email and confirm its content, formatting, and accuracy.

--- a/src/projectvote/backend/templates/email/application_confirmation.html
+++ b/src/projectvote/backend/templates/email/application_confirmation.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <p>Hallo {{ first_name }} {{ last_name }},</p>
+    <p>Vielen Dank für Ihren Förderantrag. Wir haben ihn erfolgreich erhalten.</p>
+    <p>Diese E-Mail dient als Bestätigung Ihrer Einreichung. Nachfolgend finden Sie eine Zusammenfassung Ihrer übermittelten Details:</p>
+
+    <h3>Zusammenfassung des Antrags</h3>
+    <ul>
+        <li><strong>Projekttitel:</strong> {{ project_title }}</li>
+        <li><strong>Name des Antragstellers:</strong> {{ first_name }} {{ last_name }}</li>
+        <li><strong>E-Mail des Antragstellers:</strong> {{ applicant_email }}</li>
+        <li><strong>Abteilung/Fachschaft:</strong> {{ department }}</li>
+        <li><strong>Geschätzte Kosten:</strong> €{{ costs }}</li>
+        <li><strong>Projektbeschreibung:</strong><br>{{ project_description }}</li>
+    </ul>
+
+    {% if attachment_filename %}
+    <p><strong>Anhang:</strong> Ihre Datei '{{ attachment_filename }}' wurde erfolgreich hochgeladen.</p>
+    {% endif %}
+
+    <p>Wir werden Ihren Antrag prüfen und uns nach Abschluss des Abstimmungsprozesses bei Ihnen melden.</p>
+    <p>Sie können den Status aller Anträge im <a href="{{ frontend_url }}/archive">Antragsarchiv</a> einsehen.</p>
+    <p>Mit freundlichen Grüßen,</p>
+    <p>LvD Förderverein</p>
+</body>
+</html>


### PR DESCRIPTION
Title: feat: Add application confirmation email

This pull request resolves issue #7 by implementing an automated confirmation email for applicants upon successful submission of a funding application.

**Description**

This change enhances the user experience by providing immediate, persistent confirmation that an application has been received. The email contains a full summary of the submitted data, confirmation of any file attachments, and a link to the application archive.

**Key Changes**

* Backend:
    * Added a new Jinja2 template application_confirmation.html) for the email body.
    * Implemented a send_confirmation_email function in main.py to encapsulate the email sending logic.
    * Integrated the email sending function into the /applications endpoint, which is triggered after an application is successfully saved to the database.

* Frontend:
    * The ApplicationForm now includes a file input field with client-side validation for file type and size.
    * The UI has been improved to show the selected file and allow for its removal before submission.