### PR TITLE
feat: Add `send_automatic_confirmation_email` setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,9 @@ DB_ECHO=False
 # -----------------------------------------------------------------------------
 # Email Configuration (for fastapi-mail)
 # -----------------------------------------------------------------------------
-# Send automatic rejection emails to applicants
-SEND_AUTOMATIC_REJECTION_EMAIL=true
+# Send automatic confirmation and rejection emails to applicants
+SEND_AUTOMATIC_CONFIRMATION_EMAIL=true
+SEND_AUTOMATIC_REJECTION_EMAIL=false
 
 # Example for a real SMTP server (e.g., SendGrid, Mailgun)
 MAIL_DRIVER=smtp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- ``send_automatic_confirmation_email`` setting ([GH#16](https://github.com/andreas-vester/ProjectVote/issues/16)).
+
 ## [0.4.0] - 2026-01-23
 
 ### Added
 
-- Time stamps recording the time of application creation and conclusion.
-- Time stamps recording the exact time of individual voting casts.
+- Time stamps recording the time of application creation and conclusion and time of individual voting casts ([GH#12](https://github.com/andreas-vester/ProjectVote/issues/12)).
 
 ### Changed
 

--- a/src/projectvote/backend/config.py
+++ b/src/projectvote/backend/config.py
@@ -34,7 +34,8 @@ class Settings(BaseSettings):
     # Application settings
     frontend_url: str = "http://localhost:5173"
     backend_url: str = "http://localhost:8008"
-    send_automatic_rejection_email: bool = True
+    send_automatic_confirmation_email: bool = False
+    send_automatic_rejection_email: bool = False
 
     # Database settings
     db_echo: bool = True

--- a/src/projectvote/backend/main.py
+++ b/src/projectvote/backend/main.py
@@ -271,9 +271,12 @@ async def send_final_decision_emails(
     }
 
     # --- Email to Applicant ---
-    if not (
+    if (
+        application.status == ApplicationStatus.APPROVED
+        and settings.send_automatic_confirmation_email
+    ) or (
         application.status == ApplicationStatus.REJECTED
-        and not settings.send_automatic_rejection_email
+        and settings.send_automatic_rejection_email
     ):
         await send_email(
             recipients=[application.applicant_email],


### PR DESCRIPTION
Add configuration option to control automatic confirmation emails when applications are approved, separate from rejection emails.

- Add `send_automatic_confirmation_email` setting (default: False)
- Expand test coverage with 8 parametrized scenarios

Closes #16