### PR TITLE
ci: upgrade github actions and migrate to node.js 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,17 +6,20 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   backend:
     runs-on: ubuntu-latest
     env:
       BOARD_MEMBERS: "test.member1@example.com,test.member2@example.com,test.member3@example.com"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.2.0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version-file: '.python-version'
     - name: Install dependencies
@@ -36,11 +39,11 @@ jobs:
       run:
         working-directory: ./src/projectvote/frontend
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
     - name: Install dependencies
       run: npm install
     - name: Run linter
@@ -57,17 +60,17 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -75,7 +78,7 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/projectvote-backend:latest
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./src/projectvote/frontend
           file: ./src/projectvote/frontend/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build dependencies using the official astral/uv image
-# This image contains Python 3.13 and uv pre-installed.
+# This image contains Python 3.14 and uv pre-installed.
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
 
 # Set the working directory
@@ -23,7 +23,7 @@ WORKDIR /app
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends wget; \
-    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.17/gosu-$(dpkg --print-architecture | awk -F- '{print $NF}')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-$(dpkg --print-architecture | awk -F- '{print $NF}')"; \
     chmod +x /usr/local/bin/gosu; \
     # Verify that gosu is installed and works
     gosu --version; \

--- a/src/projectvote/frontend/Dockerfile
+++ b/src/projectvote/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the React application
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/src/projectvote/frontend/package-lock.json
+++ b/src/projectvote/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "frontend",
+  "name": "projectvote-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
+      "name": "projectvote-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",


### PR DESCRIPTION
- Update all GitHub Actions to their latest major versions
- Opt-in to Node.js 24 runtime for actions via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
- Update frontend build environment to Node.js 24 (workflow and Dockerfile)
- Update gosu to v1.19 in backend Dockerfile
- Sync frontend package-lock.json with the new Node runtime