### PR TITLE
Fix(entrypoint): run chown after migrations to prevent readonly DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 	during `alembic upgrade head` are owned by `appuser`, preventing
 	"readonly database" errors when the app runs as a non-root user ([GH#25](https://github.com/andreas-vester/ProjectVote/issues/25)).
 - Standardize all database timestamps to UTC and implement localized display based on the configured timezone ([GH#22](https://github.com/andreas-vester/ProjectVote/issues/22)).
+- Allow larger attachment uploads through the frontend nginx proxy by increasing `client_max_body_size`, preventing `413 Request Entity Too Large` failures for PDF attachments.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Fix
-
-- Database migration for fresh deployments ([GH#20](https://github.com/andreas-vester/ProjectVote/issues/20)).
-
 ### Changed
 
+- Database migration for fresh deployments ([GH#20](https://github.com/andreas-vester/ProjectVote/issues/20)).
+- Ensure ownership change runs after migrations so database files created
+	during `alembic upgrade head` are owned by `appuser`, preventing
+	"readonly database" errors when the app runs as a non-root user ([GH#25](https://github.com/andreas-vester/ProjectVote/issues/25)).
 - Standardize all database timestamps to UTC and implement localized display based on the configured timezone ([GH#22](https://github.com/andreas-vester/ProjectVote/issues/22)).
 
 ### Added

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,15 +4,11 @@
 # containers that need to run as a non-root user but also need to write to
 # a bind-mounted volume owned by a host user.
 
-# 1. Set ownership of the data directory to the appuser.
-#    This ensures that the application can write to the database file,
-#    regardless of the host user's UID/GID.
-chown -R appuser:appuser /app/data
-
-# 2. Run database migrations before starting the application.
+# 1. Run database migrations before starting the application.
 #    This ensures the database schema is up-to-date with the current code.
-#    Migrations are run as root first (before dropping privileges) to ensure
-#    permissions are correct.
+#    Migrations are run as root first (before dropping privileges).
+#    This must run BEFORE chown so that any new files created during migration
+#    (e.g., applications.db) are also included in the ownership change.
 echo "Running database migrations..."
 alembic -c alembic.ini upgrade head
 if [ $? -ne 0 ]; then
@@ -20,6 +16,11 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 echo "Database migrations completed successfully"
+
+# 2. Set ownership of the data directory to the appuser.
+#    This ensures that all files (including newly created DB during migration)
+#    are writable by the application.
+chown -R appuser:appuser /app/data
 
 # 3. Execute the main command (CMD) passed to the container.
 #    `gosu` is a lightweight tool for dropping privileges.

--- a/src/projectvote/frontend/nginx.conf
+++ b/src/projectvote/frontend/nginx.conf
@@ -2,6 +2,9 @@ server {
   listen 80;
   server_name localhost;
 
+  # Allow file uploads up to 20 MB.
+  client_max_body_size 20M;
+
   location /api/ {
     proxy_pass http://backend:8008/;
     proxy_set_header Host $host;


### PR DESCRIPTION
Ensure `alembic upgrade head` runs before changing ownership so any files created during migrations (e.g. `applications.db`) are chowned to `appuser`. This prevents the application (running as `appuser`) from seeing a root-owned, read-only database file.

Closes #25