### PR TITLE
feat: display app version and update dev docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY src/ ./src/
 # Copy alembic configuration and migration scripts
 COPY alembic/ ./alembic/
 COPY alembic.ini .
+COPY pyproject.toml .
 
 # Add the virtual environment's executables to the PATH
 ENV PATH="/app/.venv/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,58 @@ The application should now be running. Docker Compose will pull the latest image
 
 We welcome contributions to ProjectVote! If you're interested in fixing bugs, adding new features, or improving the documentation, please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for details.
 
+### Local Development (without Docker)
+
+If you want to run the project natively on your machine for development:
+
+1. **Prerequisites**: Make sure you have [uv](https://docs.astral.sh/uv/) installed for Python dependency management, and Node.js (with npm) for the frontend.
+2. **Setup**:
+   - Install Python dependencies and create a virtual environment:
+     ```bash
+     uv sync
+     ```
+   - Install frontend dependencies:
+     ```bash
+     cd src/projectvote/frontend
+     npm install
+     ```
+3. **Running the Frontend**:
+   ```bash
+   cd src/projectvote/frontend
+   npm run dev
+   ```
+   *This starts the Vite dev server at http://localhost:5173 (with an API proxy pointing to http://localhost:8008).*
+4. **Running the Backend**:
+   From the project root:
+   ```bash
+   PYTHONPATH=src uv run uvicorn projectvote.backend.main:app --reload --port 8008
+   ```
+   *This starts the FastAPI server at http://localhost:8008.*
+
+### Debugging with VS Code
+
+To debug the backend natively in VS Code, add the following configuration to your `.vscode/launch.json`:
+
+```json
+{
+    "name": "Python: FastAPI Local",
+    "type": "debugpy",
+    "request": "launch",
+    "module": "uvicorn",
+    "args": [
+        "projectvote.backend.main:app",
+        "--port",
+        "8008",
+        "--reload"
+    ],
+    "env": {
+        "PYTHONPATH": "src"
+    },
+    "jinja": true
+}
+```
+Select **Python: FastAPI Local** in the Run & Debug view and press **F5** to start.
+
 ## Configuration
 
 To provide a clearer picture of the setup, here are the contents of the main configuration files.

--- a/src/projectvote/backend/main.py
+++ b/src/projectvote/backend/main.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import os
+import tomllib
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -628,3 +629,25 @@ async def get_applications_archive(
     applications = result.scalars().unique().all()
 
     return [ApplicationOut.model_validate(app) for app in applications]
+
+
+def load_version() -> str:
+    """Load application version from pyproject.toml."""
+    try:
+        pyproject_path = (
+            Path(__file__).resolve().parent.parent.parent.parent / "pyproject.toml"
+        )
+        with pyproject_path.open("rb") as f:
+            data = tomllib.load(f)
+            return data.get("project", {}).get("version", "unknown")
+    except (OSError, tomllib.TOMLDecodeError):
+        return "unknown"
+
+
+APP_VERSION = load_version()
+
+
+@app.get("/version")
+async def get_version() -> dict[str, str]:
+    """Return the application version from pyproject.toml."""
+    return {"version": APP_VERSION}

--- a/src/projectvote/frontend/src/App.tsx
+++ b/src/projectvote/frontend/src/App.tsx
@@ -1,31 +1,65 @@
+import { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link as RouterLink } from 'react-router-dom';
-import { Container, Typography, CssBaseline, AppBar, Toolbar, Button } from '@mui/material';
+import { Container, Typography, CssBaseline, AppBar, Toolbar, Button, Box } from '@mui/material';
 import ApplicationForm from './components/ApplicationForm';
 import Archive from './components/Archive';
 import VotingForm from './components/VotingForm';
+import { getVersion } from './apiService';
 
 function App() {
+  const [version, setVersion] = useState<string>('');
+
+  useEffect(() => {
+    getVersion().then(setVersion);
+  }, []);
+
   return (
     <Router>
       <CssBaseline />
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            ProjectVote
-          </Typography>
-          <Button color="inherit" component={RouterLink} to="/">Startseite</Button>
-          <Button color="inherit" component={RouterLink} to="/new">Neuer Antrag</Button>
-          <Button color="inherit" component={RouterLink} to="/archive">Archiv</Button>
-        </Toolbar>
-      </AppBar>
-      <Container component="main" sx={{ mt: 4, mb: 4 }} maxWidth="lg">
-        <Routes>
-          <Route path="/" element={<Typography>Willkommen bei der Antragsverwaltung.</Typography>} />
-          <Route path="/new" element={<ApplicationForm />} />
-          <Route path="/archive" element={<Archive />} />
-          <Route path="/vote/:token" element={<VotingForm />} />
-        </Routes>
-      </Container>
+      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+        <AppBar position="static">
+          <Toolbar>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1, display: 'flex', alignItems: 'baseline', gap: 1 }}>
+              ProjectVote
+              {version && (
+                <Typography variant="caption" sx={{ opacity: 0.8, fontSize: '0.8rem' }}>
+                  v{version}
+                </Typography>
+              )}
+            </Typography>
+            <Button color="inherit" component={RouterLink} to="/">Startseite</Button>
+            <Button color="inherit" component={RouterLink} to="/new">Neuer Antrag</Button>
+            <Button color="inherit" component={RouterLink} to="/archive">Archiv</Button>
+          </Toolbar>
+        </AppBar>
+        <Container component="main" sx={{ mt: 4, mb: 4, flex: 1 }} maxWidth="lg">
+          <Routes>
+            <Route path="/" element={<Typography>Willkommen bei der Antragsverwaltung.</Typography>} />
+            <Route path="/new" element={<ApplicationForm />} />
+            <Route path="/archive" element={<Archive />} />
+            <Route path="/vote/:token" element={<VotingForm />} />
+          </Routes>
+        </Container>
+        <Box
+          component="footer"
+          sx={{
+            py: 3,
+            px: 2,
+            mt: 'auto',
+            backgroundColor: (theme) =>
+              theme.palette.mode === 'light'
+                ? theme.palette.grey[200]
+                : theme.palette.grey[800],
+            textAlign: 'center',
+          }}
+        >
+          <Container maxWidth="lg">
+            <Typography variant="body2" color="text.secondary">
+              ProjectVote {version ? `v${version}` : ''} &copy; {new Date().getFullYear()}
+            </Typography>
+          </Container>
+        </Box>
+      </Box>
     </Router>
   );
 }

--- a/src/projectvote/frontend/src/apiService.ts
+++ b/src/projectvote/frontend/src/apiService.ts
@@ -183,3 +183,17 @@ export const getAttachmentUrl = (token: string, attachmentId: number): string =>
 export const getPublicAttachmentUrl = (attachmentId: number): string => {
   return `/api/attachments/${attachmentId}`;
 };
+
+/**
+ * Fetches the application version from the backend.
+ * @returns The version string.
+ */
+export const getVersion = async (): Promise<string> => {
+  try {
+    const response = await apiClient.get<{ version: string }>('/version');
+    return response.data.version;
+  } catch (error) {
+    console.error('Error fetching version:', error);
+    return 'unknown';
+  }
+};

--- a/src/projectvote/frontend/vite.config.ts
+++ b/src/projectvote/frontend/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8008',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
- Copy pyproject.toml to the final Docker runtime image.
- Expose a new /version GET endpoint on the backend that reads the app version from pyproject.toml on startup.
- Fetch the version in the frontend and display it in both the header (next to the logo) and in a new sticky page footer.
- Add a Vite proxy configuration for local development to forward /api requests to the backend (on port 8008) and strip the prefix.
- Update README.md with detailed instructions for running the app natively and debugging the backend in VS Code.